### PR TITLE
doc updated, better installation scripts, casanova vhanged in order to work with casa release 4.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 easy_install_casanova.sh
 casapy/
 sandbox/
-
+build*/
+env*/
 python-env
 casapy
 sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
+# Files usually created by some text editors
 *.sw?
 *\~
 *.tar.gz
 *.pyc
 *.pyo
-
 easy_install_casanova.sh
-casapy/
-sandbox/
+
+# Ignores everythin related to virtual environment or build directory (if you want to install casanova in this same directory)
 build*/
 env*/
 python-env

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,14 @@
 *.sw?
 *\~
-easy_install_casanova.sh
 *.tar.gz
 *.pyc
 *.pyo
+
+easy_install_casanova.sh
 casapy/
 sandbox/
+
+python-env
+casapy
+sandbox
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ easy_install_casanova.sh
 *.pyc
 *.pyo
 casapy/
+sandbox/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,94 @@
+## Install Caspyter locally
+
+This has been taken from GasparCorrea contribution
+ 
+## 1. Make sure you have the following dependencies
+ 
+* libice6
+* libsm6
+* libxt6
+* libxrender1
+* libfontconfig1
+* libcups2
+* libxml2
+* libxslt-dev
+* libgtk2.0-0
+* python-qt4
+ 
+## 2. Download CASA
+ 
+```
+wget https://almascience.eso.org/arcdistribution/casa-distro/linux/release/casa-release-4.5.2-el6.tar.gz
+tar zxf /home/caspyter/casa-release-4.5.2-el6.tar.gz
+```
+ 
+## 3. Install patchELF
+ 
+```
+sudo sh /path/to/caspyter/scripts/patchELF.sh
+```
+
+## 4. Install virtualenv
+
+Virtual env enables you to have side-by-side installations of python: with virtual env
+you can have different environments for python, and you avoid polluting your system
+python installation with packages you don't need for your daily normal work, and
+have independent environments for each of your developments.
+
+You can read this resource to install virtualenv on your system: [A beginners guide to use virtualenv](http://www.pythonforbeginners.com/basics/how-to-use-python-virtualenv)
+
+After installing virtual env, we are ready to create the virtual env for casanova project.
+
+### 4.1 Create a virtualenv for casanova:
+
+On casanova root folder, type this command:
+```
+virtualenv -p python2.7 python-env
+```
+
+### 4.2 Activate the new virtual environment
+
+ enter the following command
+```
+source python-env/bin/activate
+```
+
+It will create a new folder with a bare python2.7 installation, and a special script
+to activate this brand new environment, to activate it.
+
+### 4.3 Install the required python packages
+
+You will need to install several packages that are not provided with casa, but that 
+you need in your system.
+
+Also, make sure you have the package "python-dev" or "python-devel" (the name may change
+for your specific linux distribution) in order to have the header "python.h" and many others
+to compile some python packages.
+
+Then, start installing the following packages:
+
+```
+pip install ipython
+pip install jupyter
+pip install numpy
+pip install matplotlib
+```
+
+Now we're ready to install Casanova.
+
+## 4. Install Casanova
+* Edit `infodir` and `casainstalldir` parameters in `caspyter/install_casanova` file, and then run `caspyter/install_casanova`
+* Edit `caspyter` parameter in `caspyter/casanova_startup` and then add this to your `.bashrc`:
+
+```
+alias caspyter="source /path/to/caspyter/casanova_startup"
+```
+ 
+### If you get an error like `CXXABI_1.3.8' not found`, you might want to try this:
+```
+strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep CXXABI_1.3.8
+```
+If it returns `CXXABI_1.3.8`, try with:
+```
+cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/user/anaconda2/bin/../lib/libstdc++.so.6
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These instructions are for tcsh.
 
 1. Download (and unzip) the files in this repository to some directory.
 
-2. Move casa (I used casa-release-4.5.2-el6) to a directory named casapy (or so). Other directories such as python_packages will also end up in this directory.
+2. Move casa (I used casa-release-4.5.2-el6) to a directory named casapy (or so). Other directories such as python_packages will also end up in this directory. Create also a subdirectory called "python_packages"
 
 3. Download and install [patchelf](http://nixos.org/patchelf.html).
 

--- a/casanova_startup
+++ b/casanova_startup
@@ -1,16 +1,14 @@
 #!/bin/sh
 
-set oldpythonpath = "${PYTHONPATH}"
+export oldpythonpath="${PYTHONPATH}"
+user=${whoami}
+# Replace /path/to/casa
+caspyter=/path/to/casa
+export PYTHONPATH="${caspyter}/python_packages:${PYTHONPATH}"
 
-# The python_packages folder was automatically created with the install_casanova script.
-# Change this path:
-setenv PYTHONPATH "/net/dedemsvaart/data2/kvdam/casa_installation/python_packages:${PYTHONPATH}"
+export CASAPATH="${caspyter}/casa-release-4.5.2-el6 linux socorro ${user}"
 
-# Change only the first and last element of this path (linux socorro is OK)
-# The first element is the directory where the casa code is stored, so /own/path/casa-release-something
-# The last element is the computer name (in my case this was dedemsvaart) I'm not sure if this is even used but change it anyway
-setenv CASAPATH "/net/dedemsvaart/data2/kvdam/casa_installation/casa-release-4.5.2-el6  linux socorro dedemsvaart"
 
-python $argv # Or use ipython
+ipython notebook --port 8081 --ip 0.0.0.0
 
-setenv PYTHONPATH "${oldpythonpath}"
+export PYTHONPATH="${oldpythonpath}"

--- a/casanova_startup
+++ b/casanova_startup
@@ -6,7 +6,7 @@ user=${whoami}
 caspyter=/path/to/casa
 export PYTHONPATH="${caspyter}/python_packages:${PYTHONPATH}"
 
-export CASAPATH="${caspyter}/casa-release-4.5.2-el6 linux socorro ${user}"
+export CASAPATH="${caspyter}/casa-release-4.7.2-el6 linux socorro ${user}"
 
 
 ipython notebook --port 8081 --ip 0.0.0.0

--- a/install_casanova
+++ b/install_casanova
@@ -83,6 +83,7 @@ for f in lib*.so* ; do
         cp -a $f $python/__casac__ ;;
       *)
         cp -a $f $python/__casac__
+        echo patchelf --set-rpath '$ORIGIN' $python/__casac__/$f
         patchelf --set-rpath '$ORIGIN' $python/__casac__/$f ;;
     esac
   fi
@@ -91,6 +92,7 @@ done
 # patch rpaths of Python module binary files
 cd $python/__casac__
 for f in _*.so ; do
+  echo patchelf --set-rpath "$ORIGIN" $f
   patchelf --set-rpath '$ORIGIN' $f
 done
 

--- a/install_casanova
+++ b/install_casanova
@@ -27,7 +27,7 @@ fi
 mkdir -m 777 $casainstalldir/python_packages
 
 # Note that your release may differ, so possibly edit the path
-casa=$casainstalldir/casa-release-4.5.2-el6
+casa=$casainstalldir/casa-release-4.7.2-el7
 python=$casainstalldir/python_packages
 
 ########################################################################


### PR DESCRIPTION
- INSTALL.md contains the instructions to install a standalone casanova, through PIP
- casanova_startup script modified to BASH interpreter, and to work with casa 4.7.2
- install_casanova works with casa release 4.7.2. Also, it outputs some debug information when the patchelf loop is running.