### PR TITLE
install instructions with casa release 4.5.2, ready to use with virtualenv

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,10 +24,6 @@ tar zxf casa-release-4.5.2-el6.tar.gz
 
 Or, symlink your downloaded casa release to this directory
 
-```
-ln -s PATH/TO/casa-release-4.5.2-el6.tar.gz .
-```
- 
 ## 3. Install patchELF
 
 You can install it by downloading the 0.6 version from git, using Kasper's script:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
 ## Install Caspyter locally
 
-This has been taken from GasparCorrea contribution
- 
 ## 1. Make sure you have the following dependencies
+
+Install them using your package manager.
  
 * libice6
 * libsm6
@@ -19,14 +19,25 @@ This has been taken from GasparCorrea contribution
  
 ```
 wget https://almascience.eso.org/arcdistribution/casa-distro/linux/release/casa-release-4.5.2-el6.tar.gz
-tar zxf /home/caspyter/casa-release-4.5.2-el6.tar.gz
+tar zxf casa-release-4.5.2-el6.tar.gz
+```
+
+Or, symlink your downloaded casa release to this directory
+
+```
+ln -s PATH/TO/casa-release-4.5.2-el6.tar.gz .
 ```
  
 ## 3. Install patchELF
+
+You can install it by downloading the 0.6 version from git, using Kasper's script:
  
 ```
 sudo sh /path/to/caspyter/scripts/patchELF.sh
 ```
+
+Or you can install it using your package manager
+
 
 ## 4. Install virtualenv
 
@@ -76,7 +87,35 @@ pip install matplotlib
 
 Now we're ready to install Casanova.
 
-## 4. Install Casanova
+## 5. Prepare build directory
+
+Create a directory where you will install casanova
+
+```
+mkdir build
+```
+
+Go to the build directory, and symlink your casa release to it, then return to
+the project folder. If you have installed casa on the folder /opt/usr, you can
+do the following:
+
+```
+cd build
+ln -s /opt/usr/casa-release-4.5.2-el6 .
+cd ..
+```
+
+
+## 6. Install Casanova
+
+Run the script *install_casanova* with two parameters. The first one must be the
+absolute path to your casanova repository (where this file is located), and the 
+second one the absolute path to the target installation directory.
+
+```
+./install_casanova `pwd` `pwd`/build
+```
+
 * Edit `infodir` and `casainstalldir` parameters in `caspyter/install_casanova` file, and then run `caspyter/install_casanova`
 * Edit `caspyter` parameter in `caspyter/casanova_startup` and then add this to your `.bashrc`:
 
@@ -91,4 +130,5 @@ strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep CXXABI_1.3.8
 If it returns `CXXABI_1.3.8`, try with:
 ```
 cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/user/anaconda2/bin/../lib/libstdc++.so.6
+```
 

--- a/install_casanova
+++ b/install_casanova
@@ -54,7 +54,15 @@ ln -s $casa/data/geodetic/Observatories $casa/data/Observatories
 ln -s $casa/data $casainstalldir
 
 # Copy the startup script to the casa install directory
-cp $infodir/casanova_startup $casainstalldir
+# cp $infodir/casanova_startup $casainstalldir
+# Creates the startup script
+echo 'export oldpythonpath="${PYTHONPATH}"' > c.test
+echo 'user=${whoami}' >> c.test
+echo "export PYTHONPATH=\"${casainstalldir}/python_packages:\${PYTHONPATH}\"" >> c.test
+echo "export CASAPATH=\"${casainstalldir}/casa-release-4.5.2-el6 linux socorro ${user}\"" >> c.test
+echo 'ipython notebook --port 8081 --ip 0.0.0.0' >> c.test
+echo 'export PYTHONPATH="${oldpythonpath}"' >> c.test
+
 
 # Add the new ftw() task
 cp $infodir/code/task_ftw.* $python

--- a/install_casanova
+++ b/install_casanova
@@ -27,7 +27,7 @@ fi
 mkdir -m 777 $casainstalldir/python_packages
 
 # Note that your release may differ, so possibly edit the path
-casa=$casainstalldir/casa-release-4.7.2-el7
+casa=$casainstalldir/casa-release-4.5.2-el6
 python=$casainstalldir/python_packages
 
 ########################################################################

--- a/install_casanova
+++ b/install_casanova
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 if [ $# -eq 0 ]
 then
@@ -53,16 +53,25 @@ cp $infodir/code/__init__.py $python/casat
 ln -s $casa/data/geodetic/Observatories $casa/data/Observatories
 ln -s $casa/data $casainstalldir
 
-# Copy the startup script to the casa install directory
-# cp $infodir/casanova_startup $casainstalldir
-# Creates the startup script
-echo 'export oldpythonpath="${PYTHONPATH}"' > c.test
-echo 'user=${whoami}' >> c.test
-echo "export PYTHONPATH=\"${casainstalldir}/python_packages:\${PYTHONPATH}\"" >> c.test
-echo "export CASAPATH=\"${casainstalldir}/casa-release-4.5.2-el6 linux socorro ${user}\"" >> c.test
-echo 'ipython notebook --port 8081 --ip 0.0.0.0' >> c.test
-echo 'export PYTHONPATH="${oldpythonpath}"' >> c.test
+# Creates the jupyter startup script
+echo '#!/bin/bash' > ${casainstalldir}/jupyter_casanova.sh
+echo 'export oldpythonpath="${PYTHONPATH}"' >> ${casainstalldir}/jupyter_casanova.sh
+echo 'user=${whoami}' >> ${casainstalldir}/jupyter_casanova.sh
+echo "export PYTHONPATH=\"${casainstalldir}/python_packages:\${PYTHONPATH}\"" >> ${casainstalldir}/jupyter_casanova.sh
+echo "export CASAPATH=\"${casainstalldir}/casa-release-4.5.2-el6 linux socorro ${user}\"" >> ${casainstalldir}/jupyter_casanova.sh
+echo 'ipython notebook --port 8081 --ip 0.0.0.0' >> ${casainstalldir}/jupyter_casanova.sh
+echo 'export PYTHONPATH="${oldpythonpath}"' >> ${casainstalldir}/jupyter_casanova.sh
+chomod +x ${casainstalldir}/jupyter_casanova.sh
 
+# Creates the ipython startup script
+echo '#!/bin/bash' > ${casainstalldir}/ipython_casanova.sh
+echo 'export oldpythonpath="${PYTHONPATH}"' >> ${casainstalldir}/ipython_casanova.sh
+echo 'user=${whoami}' >> ${casainstalldir}/ipython_casanova.sh
+echo "export PYTHONPATH=\"${casainstalldir}/python_packages:\${PYTHONPATH}\"" >> ${casainstalldir}/ipython_casanova.sh
+echo "export CASAPATH=\"${casainstalldir}/casa-release-4.5.2-el6 linux socorro ${user}\"" >> ${casainstalldir}/ipython_casanova.sh
+echo 'ipython' >> ${casainstalldir}/ipython_casanova.sh
+echo 'export PYTHONPATH="${oldpythonpath}"' >> ${casainstalldir}/ipython_casanova.sh
+chmod +x ${casainstalldir}/ipython_casanova.sh
 
 # Add the new ftw() task
 cp $infodir/code/task_ftw.* $python


### PR DESCRIPTION
- install_casanova script updated to work with casa-release-4.5.2
- install_casanova script cleaned up, every parameter must be given as an argument to this script
- install_casanova script now creates automatically the casanova_startup script. Before, the user had to edit this file in order to launch casanova in his computer. Now, the installation script creates a startup script to launch jupyter and other one to launch ipython
- install instructions updated, if every step is followeb using virtualenv, you should have casanova installed properly on your computer